### PR TITLE
fix FromLow for eng words

### DIFF
--- a/all.xslt
+++ b/all.xslt
@@ -932,7 +932,7 @@
         select="concat(lower-case(substring($string[1], 1, 1)), substring($string[1], 2))"/>
     </xsl:variable>
     <xsl:if test="string-length($string[1]) &gt; 0">
-      <xsl:analyze-string select="substring($string[1], 1, 1)" regex="[A-Z]">
+      <xsl:analyze-string select="substring($string[1], 1, 1)" regex="[A-Z][a-z]">
         <xsl:matching-substring>
           <xsl:value-of select="$string[1]"/>
         </xsl:matching-substring>


### PR DESCRIPTION
Как я понял, то функция analyze-string проверяет только заглавные буквы, а нам нужно, чтобы выводила еще и строчные буквы в случае string-ltrim.
Для этого в регулярное выражение я добавил их анализ. 